### PR TITLE
remove default styles

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return array(
 	'label' => 'xmlEdit',
 	'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '1.0.0',
+    'version' => '1.1.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'tao' => '>=2.12.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -54,7 +54,7 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->setVersion($currentVersion);
-        $this->skip('0.2.0', '1.0.0');
+        $this->skip('0.2.0', '1.1.0');
     }
 
 

--- a/views/js/editor.js
+++ b/views/js/editor.js
@@ -25,17 +25,12 @@ define([
 ], function(_, $, vkBeautify){
 
     'use strict';
-    
+
     var _ns = '.xml-editor';
-    
+
     var _defaults = {
         readonly : false,
         hidden :false,
-        top : 0,
-        left : 0,
-        width : '800px',
-        height : '500px',
-        zIndex : 1,
         minifyOutput : false
     };
 
@@ -48,7 +43,7 @@ define([
     function formatXml(xml){
         return vkBeautify.xml(xml, '\t');
     }
-    
+
     /**
      * Compress the xml string into a single line
      * @private
@@ -56,11 +51,11 @@ define([
      * @returns {string}
      */
     function compressXml(xml){
-        return xml.replace(/[ \r\n\t]{1,}xmlns/g, ' xmlns').replace(/>\s{0,}</g,"><"); 
+        return xml.replace(/[ \r\n\t]{1,}xmlns/g, ' xmlns').replace(/>\s{0,}</g,"><");
     }
     /**
      * Init the previewer on a container and returns an api to control it
-     * 
+     *
      * @param {jQuery} $container
      * @param {object} options
      * @param {boolean} [options.readonly] - not editable
@@ -79,7 +74,7 @@ define([
         var editor = ace.edit($editor[0]);
 
         options = _.defaults(options || {}, _defaults);
-        
+
         editor.$blockScrolling = Infinity;//add this fix as suggested by ace to prevent message in console
         editor.setTheme("ace/theme/chrome");
         editor.getSession().setMode("ace/mode/xml");
@@ -100,11 +95,11 @@ define([
                 height : options.height,
                 zIndex : options.zIndex
             });
-        
+
         if(options.hidden){
             $container.hide();
         }
-        
+
         /**
          * Set the editor content
          * @param {string} xml
@@ -113,10 +108,10 @@ define([
             xml = formatXml(xml);
             editor.getSession().setValue(xml);
         }
-        
+
         /**
          * Get the editor content
-         *  
+         *
          * @returns {string}
          */
         function getValue(){
@@ -126,12 +121,12 @@ define([
             }
             return value;
         }
-        
+
         /**
          * Destroy the editor
          */
         function destroy(){
-            
+
             editor.destroy();
             $container
                 .off(_ns)
@@ -139,7 +134,7 @@ define([
                 .removeAttr('style')
                 .children('.tao-ace-editor').remove();
         }
-        
+
         return {
             setValue : setValue,
             getValue : getValue,


### PR DESCRIPTION
In order to override them completely using CSS, for example using a `calc` value.