### PR TITLE
Task/tao 4692 migrate to libsass

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return array(
 	'label' => 'xmlEdit',
 	'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '2.0.0',
+    'version' => '2.0.1',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'tao' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -23,14 +23,14 @@ use oat\tao\model\ClientLibRegistry;
 use oat\tao\model\ClientLibConfigRegistry;
 
 /**
- * 
+ *
  * @author Sam <sam@taotesting.com>
  */
 class Updater extends common_ext_ExtensionUpdater
 {
 
     /**
-     * 
+     *
      * @param string $initialVersion
      * @return string $versionUpdatedTo
      */
@@ -38,24 +38,23 @@ class Updater extends common_ext_ExtensionUpdater
     {
 
         $currentVersion = $initialVersion;
-        
-        if ($currentVersion === '0.1') {
 
+        if ($currentVersion === '0.1') {
             ClientLibRegistry::getRegistry()->register('ace', ROOT_URL.'xmlEdit/views/js/lib/ace-1.2.0/');
-            ClientLibConfigRegistry::getRegistry()->register('taoQtiItem/controller/apip-creator/main', array('hooks' => array(
-                'xmlEdit/hooks/apipCreatorDebugger/hook'
-            )));
-            ClientLibConfigRegistry::getRegistry()->register('taoQtiItem/controller/creator/main', array('hooks' => array(
-                'xmlEdit/hooks/qtiCreatorDebugger/hook'
-            )));
-            
+            ClientLibConfigRegistry::getRegistry()->register(
+                'taoQtiItem/controller/apip-creator/main',
+                array('hooks' => array('xmlEdit/hooks/apipCreatorDebugger/hook'))
+            );
+            ClientLibConfigRegistry::getRegistry()->register(
+                'taoQtiItem/controller/creator/main',
+                array('hooks' => array('xmlEdit/hooks/qtiCreatorDebugger/hook'))
+            );
+
             $currentVersion = '0.2.0';
-            
         }
 
         $this->setVersion($currentVersion);
-        $this->skip('0.2.0', '2.0.0');
+
+        $this->skip('0.2.0', '2.0.1');
     }
-
-
 }

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,4 +1,5 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
+    'use strict';
 
     var sass    = grunt.config('sass') || {};
     var watch   = grunt.config('watch') || {};
@@ -7,9 +8,7 @@ module.exports = function(grunt) {
 
     //override load path
     sass.xmledit = {
-        options : {
-            loadPath : ['../scss/', '../js/lib/', root + 'scss/inc', root + 'scss/qti']
-        },
+        options : {},
         files : {}
     };
 

--- a/views/css/editor.css
+++ b/views/css/editor.css
@@ -1,2 +1,3 @@
 .tao-xml-editor{position:relative}.tao-xml-editor .ace_editor.tao-ace-editor{position:absolute;top:0;right:0;bottom:0;left:0}.tao-xml-editor .ace_editor.tao-ace-editor .ace_layer div{white-space:pre}
+
 /*# sourceMappingURL=editor.css.map */

--- a/views/css/editor.css.map
+++ b/views/css/editor.css.map
@@ -1,7 +1,14 @@
 {
-"version": 3,
-"mappings": "AAGA,eAAgB,CACZ,QAAQ,CAAE,QAAQ,CAClB,0CAA2B,CACvB,QAAQ,CAAE,QAAQ,CAClB,GAAG,CAAE,CAAC,CACN,KAAK,CAAE,CAAC,CACR,MAAM,CAAE,CAAC,CACT,IAAI,CAAE,CAAC,CACP,yDAAc,CACV,WAAW,CAAC,GAAG",
-"sources": ["../scss/editor.scss"],
-"names": [],
-"file": "editor.css"
+	"version": 3,
+	"file": "editor.css",
+	"sources": [
+		"../scss/editor.scss",
+		"../../../tao/views/scss/inc/_bootstrap.scss",
+		"../../../tao/views/scss/inc/_variables.scss",
+		"../../../tao/views/scss/inc/_functions.scss",
+		"../../../tao/views/scss/inc/_colors.scss",
+		"../../../tao/views/scss/inc/fonts/_tao-icon-vars.scss"
+	],
+	"names": [],
+	"mappings": "AAGA,AAAA,eAAe,AAAC,CACZ,QAAQ,CAAE,QAAQ,CAWrB,AAZD,AAEI,eAFW,CAEX,WAAW,AAAA,eAAe,AAAC,CACvB,QAAQ,CAAE,QAAQ,CAClB,GAAG,CAAE,CAAC,CACN,KAAK,CAAE,CAAC,CACR,MAAM,CAAE,CAAC,CACT,IAAI,CAAE,CAAC,CAIV,AAXL,AAQmB,eARJ,CAEX,WAAW,AAAA,eAAe,CAMtB,UAAU,CAAC,GAAG,AAAA,CACV,WAAW,CAAC,GAAG,CAClB"
 }


### PR DESCRIPTION
Task - Tao
Jira: https://oat-sa.atlassian.net/browse/TAO-4692

Companion (but does not require):
- https://github.com/oat-sa/tao-core/pull/1410

This pr is meant to accompany the switch to libsass. Because the grunt sass script does not require a loadPath/includeFiles sass option, it is compatible with both ruby sass and libsass.