### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return array(
 	'label' => 'xmlEdit',
 	'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '3.0.0',
+    'version' => '3.0.1',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'tao' => '>=21.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -23,10 +23,10 @@ return array(
 	'label' => 'xmlEdit',
 	'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '3.0.1',
+    'version' => '3.1.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
-        'tao' => '>=21.0.0',
+        'tao' => '>=30.0.0',
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#xmlEditManager',
     'acl' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -55,6 +55,6 @@ class Updater extends common_ext_ExtensionUpdater
 
         $this->setVersion($currentVersion);
 
-        $this->skip('0.2.0', '3.0.0');
+        $this->skip('0.2.0', '3.0.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -55,6 +55,6 @@ class Updater extends common_ext_ExtensionUpdater
 
         $this->setVersion($currentVersion);
 
-        $this->skip('0.2.0', '3.0.1');
+        $this->skip('0.2.0', '3.1.0');
     }
 }

--- a/views/js/test/editor/test.html
+++ b/views/js/test/editor/test.html
@@ -7,8 +7,8 @@
 
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking"  data-cover-only="viewer.js"></script>
         

--- a/views/js/test/editor/test.js
+++ b/views/js/test/editor/test.js
@@ -1,67 +1,66 @@
-define([
-    'lodash',
-    'jquery',
-    'xmlEdit/editor'
-], function(_, $, xmlEditor){
+define( [  'lodash', 'jquery', 'xmlEdit/editor' ], function(  _, $, xmlEditor ) {
 
     'use strict';
 
-    QUnit.test('api', function(assert){
-        
-        var editor; 
-        var $editor = $('#editor');
-        
-        assert.ok(_.isPlainObject(xmlEditor), 'init xmlEditor');
-        assert.ok(_.isFunction(xmlEditor.init), 'has init function');
+    QUnit.test( 'api', function( assert ) {
 
-        editor = xmlEditor.init($editor);
+        var editor;
+        var $editor = $( '#editor' );
 
-        assert.ok(_.isPlainObject(editor), 'init returns an object');
-        assert.ok(_.isFunction(editor.setValue), 'has setValue() fonction');
-        assert.ok(_.isFunction(editor.getValue), 'has getValue() fonction');
-        assert.ok(_.isFunction(editor.destroy), 'has destroy() fonction');
-        assert.ok(_.isFunction(editor.show), 'has show() fonction');
-        assert.ok(_.isFunction(editor.hide), 'has hide() fonction');
-    });
+        assert.ok( _.isPlainObject( xmlEditor ), 'init xmlEditor' );
+        assert.ok( _.isFunction( xmlEditor.init ), 'has init function' );
 
-    QUnit.asyncTest('get/setValue', 4, function(assert){
-        
-        var editor; 
-        var $editor = $('#editor');
-        var xml = '<?xml version="1.0" encoding="UTF-8"?><assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"    identifier="match-single-cardinality" title="Associate Things" adaptive="false" timeDependent="false" label="" xml:lang="en-US" toolName="TAO" toolVersion="3.1.0-sprint05"><responseDeclaration identifier="RESPONSE" cardinality="single" baseType="directedPair"><correctResponse><value><![CDATA[M C]]></value></correctResponse></responseDeclaration><outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" /><itemBody><matchInteraction responseIdentifier="RESPONSE" shuffle="true" maxAssociations="1" minAssociations="1"><prompt>Please mark the unique valid association below:</prompt><simpleMatchSet><simpleAssociableChoice identifier="M" fixed="false" matchMax="1" matchMin="0" showHide="show">Mouse</simpleAssociableChoice><simpleAssociableChoice identifier="S" fixed="false" matchMax="1" matchMin="0" showHide="show">Soda</simpleAssociableChoice><simpleAssociableChoice identifier="W" fixed="false" matchMax="1" matchMin="0" showHide="show">Wheel</simpleAssociableChoice><simpleAssociableChoice identifier="D" fixed="false" matchMax="1" matchMin="0" showHide="show">Darth Vader</simpleAssociableChoice></simpleMatchSet><simpleMatchSet><simpleAssociableChoice identifier="A" fixed="false" matchMax="1" matchMin="0" showHide="show">Astronaut</simpleAssociableChoice><simpleAssociableChoice identifier="C" fixed="false" matchMax="1" matchMin="0" showHide="show">Computer</simpleAssociableChoice><simpleAssociableChoice identifier="P" fixed="false" matchMax="1" matchMin="0" showHide="show">Plane</simpleAssociableChoice><simpleAssociableChoice identifier="N" fixed="false" matchMax="1" matchMin="0" showHide="show">Number</simpleAssociableChoice></simpleMatchSet></matchInteraction></itemBody><responseProcessing template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/></assessmentItem>';
+        editor = xmlEditor.init( $editor );
 
-        $editor.on('change.xml-editor', function(e, value){
-            assert.equal(value, xml, 'xml set');
-            QUnit.start();
-        });
+        assert.ok( _.isPlainObject( editor ), 'init returns an object' );
+        assert.ok( _.isFunction( editor.setValue ), 'has setValue() fonction' );
+        assert.ok( _.isFunction( editor.getValue ), 'has getValue() fonction' );
+        assert.ok( _.isFunction( editor.destroy ), 'has destroy() fonction' );
+        assert.ok( _.isFunction( editor.show ), 'has show() fonction' );
+        assert.ok( _.isFunction( editor.hide ), 'has hide() fonction' );
+    } );
 
-        editor = xmlEditor.init($editor);
-        assert.ok($editor.hasClass('tao-xml-editor'), 'xml editor container class added');
-        assert.equal($editor.find('.tao-ace-editor').length, 1, 'ace editor found');
-        
-        editor.setValue(xml);
-        assert.equal(editor.getValue(), xml, 'xml set');
-    });
-    
-    QUnit.test('destroy', function(assert){
-        
-        var $editor = $('#editor');
-        var editor = xmlEditor.init($editor);
-        
-        assert.ok($editor.hasClass('tao-xml-editor'), 'xml editor container class added');
-        assert.equal($editor.find('.tao-ace-editor').length, 1, 'ace editor found');
-        
+    QUnit.test( 'get/setValue', function( assert ) {
+        var ready = assert.async();
+
+        var editor;
+        var $editor = $( '#editor' );
+        var xml = '<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><assessmentItemxmlns=\\"http://www.imsglobal.org/xsd/imsqti_v2p1\\"xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xsi:schemaLocation=\\"http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd\\"    identifier=\\"match-single-cardinality\\" title=\\"Associate Things\\" adaptive=\\"false\\" timeDependent=\\"false\\" label=\\"\\" xml:lang=\\"en-US\\" toolName=\\"TAO\\" toolVersion=\\"3.1.0-sprint05\\"><responseDeclaration identifier=\\"RESPONSE\\" cardinality=\\"single\\" baseType=\\"directedPair\\"><correctResponse><value><![CDATA[M C]]></value></correctResponse></responseDeclaration><outcomeDeclaration identifier=\\"SCORE\\" cardinality=\\"single\\" baseType=\\"float\\" /><itemBody><matchInteraction responseIdentifier=\\"RESPONSE\\" shuffle=\\"true\\" maxAssociations=\\"1\\" minAssociations=\\"1\\"><prompt>Please mark the unique valid association below:</prompt><simpleMatchSet><simpleAssociableChoice identifier=\\"M\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Mouse</simpleAssociableChoice><simpleAssociableChoice identifier=\\"S\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Soda</simpleAssociableChoice><simpleAssociableChoice identifier=\\"W\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Wheel</simpleAssociableChoice><simpleAssociableChoice identifier=\\"D\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Darth Vader</simpleAssociableChoice></simpleMatchSet><simpleMatchSet><simpleAssociableChoice identifier=\\"A\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Astronaut</simpleAssociableChoice><simpleAssociableChoice identifier=\\"C\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Computer</simpleAssociableChoice><simpleAssociableChoice identifier=\\"P\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Plane</simpleAssociableChoice><simpleAssociableChoice identifier=\\"N\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Number</simpleAssociableChoice></simpleMatchSet></matchInteraction></itemBody><responseProcessing template=\\"http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct\\"/></assessmentItem>';
+
+        $editor.on( 'change.xml-editor', function( e, value ) {
+            assert.equal( value.replace(/\n|\t/g, ''), xml, 'xml set' );
+            ready();
+        } );
+
+        editor = xmlEditor.init( $editor );
+        assert.ok( $editor.hasClass( 'tao-xml-editor' ), 'xml editor container class added' );
+        assert.equal( $editor.find( '.tao-ace-editor' ).length, 1, 'ace editor found' );
+
+        editor.setValue( xml );
+        assert.equal( editor.getValue().replace(/\n|\t/g, ''), xml, 'xml set' );
+    } );
+
+    QUnit.test( 'destroy', function( assert ) {
+
+        var $editor = $( '#editor' );
+        var editor = xmlEditor.init( $editor );
+
+        assert.ok( $editor.hasClass( 'tao-xml-editor' ), 'xml editor container class added' );
+        assert.equal( $editor.find( '.tao-ace-editor' ).length, 1, 'ace editor found' );
+
         editor.destroy();
-        assert.ok(!$editor.hasClass('tao-xml-editor'), 'xml editor container class restored');
-        assert.equal($editor.find('.tao-ace-editor').length, 0, 'ace editor removed');
-    });
+        assert.ok( !$editor.hasClass( 'tao-xml-editor' ), 'xml editor container class restored' );
+        assert.equal( $editor.find( '.tao-ace-editor' ).length, 0, 'ace editor removed' );
+    } );
 
-    QUnit.test('visual test', 0, function(assert){
-        var xml = '<?xml version="1.0" encoding="UTF-8"?><assessmentItem xmlns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd"    identifier="match-single-cardinality" title="Associate Things" adaptive="false" timeDependent="false" label="" xml:lang="en-US" toolName="TAO" toolVersion="3.1.0-sprint05"><responseDeclaration identifier="RESPONSE" cardinality="single" baseType="directedPair"><correctResponse><value><![CDATA[M C]]></value></correctResponse></responseDeclaration><outcomeDeclaration identifier="SCORE" cardinality="single" baseType="float" /><itemBody><matchInteraction responseIdentifier="RESPONSE" shuffle="true" maxAssociations="1" minAssociations="1"><prompt>Please mark the unique valid association below:</prompt><simpleMatchSet><simpleAssociableChoice identifier="M" fixed="false" matchMax="1" matchMin="0" showHide="show">Mouse</simpleAssociableChoice><simpleAssociableChoice identifier="S" fixed="false" matchMax="1" matchMin="0" showHide="show">Soda</simpleAssociableChoice><simpleAssociableChoice identifier="W" fixed="false" matchMax="1" matchMin="0" showHide="show">Wheel</simpleAssociableChoice><simpleAssociableChoice identifier="D" fixed="false" matchMax="1" matchMin="0" showHide="show">Darth Vader</simpleAssociableChoice></simpleMatchSet><simpleMatchSet><simpleAssociableChoice identifier="A" fixed="false" matchMax="1" matchMin="0" showHide="show">Astronaut</simpleAssociableChoice><simpleAssociableChoice identifier="C" fixed="false" matchMax="1" matchMin="0" showHide="show">Computer</simpleAssociableChoice><simpleAssociableChoice identifier="P" fixed="false" matchMax="1" matchMin="0" showHide="show">Plane</simpleAssociableChoice><simpleAssociableChoice identifier="N" fixed="false" matchMax="1" matchMin="0" showHide="show">Number</simpleAssociableChoice></simpleMatchSet></matchInteraction></itemBody><responseProcessing template="http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct"/></assessmentItem>';
-        xmlEditor.init($('#editor-visual'), {
-            top : '320px',
-            left : '20px',
-            readonly : false
-        }).setValue(xml);
-    });
-});
+    QUnit.test( 'visual test', function( assert ) {
+        var xml = '<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><assessmentItemxmlns=\\"http://www.imsglobal.org/xsd/imsqti_v2p1\\"xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xsi:schemaLocation=\\"http://www.imsglobal.org/xsd/imsqti_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1.xsd\\"    identifier=\\"match-single-cardinality\\" title=\\"Associate Things\\" adaptive=\\"false\\" timeDependent=\\"false\\" label=\\"\\" xml:lang=\\"en-US\\" toolName=\\"TAO\\" toolVersion=\\"3.1.0-sprint05\\"><responseDeclaration identifier=\\"RESPONSE\\" cardinality=\\"single\\" baseType=\\"directedPair\\"><correctResponse><value><![CDATA[M C]]></value></correctResponse></responseDeclaration><outcomeDeclaration identifier=\\"SCORE\\" cardinality=\\"single\\" baseType=\\"float\\" /><itemBody><matchInteraction responseIdentifier=\\"RESPONSE\\" shuffle=\\"true\\" maxAssociations=\\"1\\" minAssociations=\\"1\\"><prompt>Please mark the unique valid association below:</prompt><simpleMatchSet><simpleAssociableChoice identifier=\\"M\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Mouse</simpleAssociableChoice><simpleAssociableChoice identifier=\\"S\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Soda</simpleAssociableChoice><simpleAssociableChoice identifier=\\"W\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Wheel</simpleAssociableChoice><simpleAssociableChoice identifier=\\"D\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Darth Vader</simpleAssociableChoice></simpleMatchSet><simpleMatchSet><simpleAssociableChoice identifier=\\"A\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Astronaut</simpleAssociableChoice><simpleAssociableChoice identifier=\\"C\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Computer</simpleAssociableChoice><simpleAssociableChoice identifier=\\"P\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Plane</simpleAssociableChoice><simpleAssociableChoice identifier=\\"N\\" fixed=\\"false\\" matchMax=\\"1\\" matchMin=\\"0\\" showHide=\\"show\\">Number</simpleAssociableChoice></simpleMatchSet></matchInteraction></itemBody><responseProcessing template=\\"http://www.imsglobal.org/question/qti_v2p1/rptemplates/match_correct\\"/></assessmentItem>';
+        xmlEditor.init( $( '#editor-visual' ), {
+            top: '320px',
+            left: '20px',
+            readonly: false
+        } ).setValue( xml );
+        assert.ok(true,'visual test passed')
+
+    } );
+} );


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs**

https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-task-queue/pull/83
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44