### PR TITLE
Fix/tao 8915/register proper ace version

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return array(
 	'label' => 'xmlEdit',
 	'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '3.2.0',
+    'version' => '3.2.1',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'tao' => '>=30.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     ),
     'install' => array(
         'php' => array(
-			dirname(__FILE__).'/scripts/install/setAceAlias.php'
+            \oat\xmlEdit\scripts\install\RegisterAceAlias::class
 		)
     ),
     'uninstall' => array(

--- a/scripts/install/RegisterAceAlias.php
+++ b/scripts/install/RegisterAceAlias.php
@@ -14,8 +14,22 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2019 (original work) Open Assessment Technologies SA ;
  *
  */
+namespace oat\xmlEdit\scripts\install;
+
+use common_report_Report as Report;
+use oat\oatbox\extension\InstallAction;
 use oat\tao\model\ClientLibRegistry;
-ClientLibRegistry::getRegistry()->register('ace', ROOT_URL.'xmlEdit/views/js/lib/ace-1.2.0/');
+
+class RegisterAceAlias extends InstallAction
+{
+    public function __invoke($params)
+    {
+        ClientLibRegistry::getRegistry()->register('ace', ROOT_URL.'xmlEdit/views/js/lib/ace-1.4.5/');
+
+        // report the result
+        return new Report(Report::TYPE_SUCCESS, 'Ace library registered!');
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -57,10 +57,10 @@ class Updater extends common_ext_ExtensionUpdater
 
         $this->skip('0.2.0', '3.1.0');
 
-        if ($this->isVersion('3.1.0')) {
+        if ($this->isBetween('3.1.0', '3.2.0')) {
             ClientLibRegistry::getRegistry()->register('ace', ROOT_URL.'xmlEdit/views/js/lib/ace-1.4.5/');
 
-            $this->setVersion('3.2.0');
+            $this->setVersion('3.2.1');
         }
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8915

While updating the library `ace.js` to `1.4.5`, the installer part has been forgotten.
