### PR TITLE
chore: update methods to lodash 4 version

### DIFF
--- a/views/js/lib/ace-1.4.5/worker-javascript.js
+++ b/views/js/lib/ace-1.4.5/worker-javascript.js
@@ -4060,8 +4060,8 @@ var JSHINT = (function() {
     var isDangerous =
       state.option.asi &&
       state.tokens.prev.line !== startLine(state.tokens.curr) &&
-      _.contains(["]", ")"], state.tokens.prev.id) &&
-      _.contains(["[", "("], state.tokens.curr.id);
+      _.includes(["]", ")"], state.tokens.prev.id) &&
+      _.includes(["[", "("], state.tokens.curr.id);
 
     if (isDangerous)
       warning("W014", state.tokens.curr, state.tokens.curr.id);
@@ -4410,7 +4410,7 @@ var JSHINT = (function() {
     values = state.inES6() ? typeofValues.es6 : typeofValues.es3;
 
     if (right.type === "(identifier)" && right.value === "typeof" && left.type === "(string)")
-      return !_.contains(values, left.value);
+      return !_.includes(values, left.value);
 
     return false;
   }
@@ -5639,7 +5639,7 @@ var JSHINT = (function() {
     advance("(");
     state.funct["(comparray)"].setState("define");
     res.left = expression(130);
-    if (_.contains(["in", "of"], state.tokens.next.value)) {
+    if (_.includes(["in", "of"], state.tokens.next.value)) {
       advance();
     } else {
       error("E045", state.tokens.curr);
@@ -5803,7 +5803,7 @@ var JSHINT = (function() {
       arity++;
       var currentParams = [];
 
-      if (_.contains(["{", "["], state.tokens.next.id)) {
+      if (_.includes(["{", "["], state.tokens.next.id)) {
         tokens = destructuringPattern();
         for (t in tokens) {
           t = tokens[t];
@@ -6411,7 +6411,7 @@ var JSHINT = (function() {
     statement.first = [];
     for (;;) {
       var names = [];
-      if (_.contains(["{", "["], state.tokens.next.value)) {
+      if (_.includes(["{", "["], state.tokens.next.value)) {
         tokens = destructuringPattern();
         lone = false;
       } else {
@@ -6497,7 +6497,7 @@ var JSHINT = (function() {
     this.first = [];
     for (;;) {
       var names = [];
-      if (_.contains(["{", "["], state.tokens.next.value)) {
+      if (_.includes(["{", "["], state.tokens.next.value)) {
         tokens = destructuringPattern();
         lone = false;
       } else {
@@ -6824,7 +6824,7 @@ var JSHINT = (function() {
 
       if (checkPunctuators(state.tokens.next, ["[", "{"])) {
         var tokens = destructuringPattern();
-        _.each(tokens, function(token) {
+        _.forEach(tokens, function(token) {
           if (token.id) {
             state.funct["(scope)"].addParam(token.id, token, "exception");
           }
@@ -7070,9 +7070,9 @@ var JSHINT = (function() {
         if (!comma && checkPunctuator(nextop, ",")) comma = nextop;
         else if (!initializer && checkPunctuator(nextop, "=")) initializer = nextop;
       }
-    } while (level > 0 || !_.contains(inof, nextop.value) && nextop.value !== ";" &&
+    } while (level > 0 || !_.includes(inof, nextop.value) && nextop.value !== ";" &&
     nextop.type !== "(end)"); // Is this a JSCS bug? This looks really weird.
-    if (_.contains(inof, nextop.value)) {
+    if (_.includes(inof, nextop.value)) {
       if (!state.inES6() && nextop.value === "of") {
         warning("W104", nextop, "for of", "6");
       }
@@ -7628,7 +7628,7 @@ var JSHINT = (function() {
   }
   function checkPunctuators(token, values) {
     if (token.type === "(punctuator)") {
-      return _.contains(values, token.value);
+      return _.includes(values, token.value);
     }
     return false;
   }
@@ -7692,7 +7692,7 @@ var JSHINT = (function() {
           _current = _carrays[_carrays.length - 1];
         },
         setState: function(s) {
-          if (_.contains(["use", "define", "generate", "filter"], s))
+          if (_.includes(["use", "define", "generate", "filter"], s))
             _current.mode = s;
         },
         check: function(v) {
@@ -9943,15 +9943,15 @@ exports.errors = {};
 exports.warnings = {};
 exports.info = {};
 
-_.each(errors, function(desc, code) {
+_.forEach(errors, function(desc, code) {
   exports.errors[code] = { code: code, desc: desc };
 });
 
-_.each(warnings, function(desc, code) {
+_.forEach(warnings, function(desc, code) {
   exports.warnings[code] = { code: code, desc: desc };
 });
 
-_.each(info, function(desc, code) {
+_.forEach(info, function(desc, code) {
   exports.info[code] = { code: code, desc: desc };
 });
 

--- a/views/js/lib/ace-1.4.5/worker-xquery.js
+++ b/views/js/lib/ace-1.4.5/worker-xquery.js
@@ -53351,7 +53351,7 @@ exports.XQLint = function (source, opts) {
     return htmlUnescapes[chr];
   }
   function runInContext(context) {
-    context = context ? _.defaults(root.Object(), context, _.pick(root, contextProps)) : root;
+    context = context ? _.defaults(root.Object(), context, _.pickBy(root, contextProps)) : root;
     var Array = context.Array,
         Date = context.Date,
         Error = context.Error,


### PR DESCRIPTION
Related: https://oat-sa.atlassian.net/browse/ADF-1579
Update lodash methods to version 4.
Documentation: https://github.com/lodash/lodash/wiki/Migrating